### PR TITLE
hackathon_app: convert dates to ISO timestamps

### DIFF
--- a/python/hackathon_app/tests/data/data.json
+++ b/python/hackathon_app/tests/data/data.json
@@ -65,7 +65,7 @@
                                 },
                                 {
                                     "userEnteredValue": {
-                                        "stringValue": "5/1/2012"
+                                        "stringValue": "2012-05-04T15:52:27.498123+00:00"
                                     }
                                 },
                                 {
@@ -104,7 +104,7 @@
                                 },
                                 {
                                     "userEnteredValue": {
-                                        "stringValue": "5/1/2018"
+                                        "stringValue": "2018-11-04T15:52:27.498123+00:00"
                                     }
                                 },
                                 {
@@ -143,7 +143,7 @@
                                 },
                                 {
                                     "userEnteredValue": {
-                                        "stringValue": "4/15/2019"
+                                        "stringValue": "2019-11-09T15:52:27.498123+00:00"
                                     }
                                 },
                                 {
@@ -182,7 +182,7 @@
                                 },
                                 {
                                     "userEnteredValue": {
-                                        "stringValue": "2/20/2019"
+                                        "stringValue": "2019-02-20T15:52:27.498123+00:00"
                                     }
                                 },
                                 {
@@ -251,7 +251,7 @@
                                 },
                                 {
                                     "userEnteredValue": {
-                                        "stringValue": "11/20/2025"
+                                        "stringValue": "2025-11-20T15:00:00.000000+00:00"
                                     }
                                 },
                                 {
@@ -275,7 +275,7 @@
                                 },
                                 {
                                     "userEnteredValue": {
-                                        "stringValue": "11/20/2026"
+                                        "stringValue": "2026-11-20T15:00:00.000000+00:00"
                                     }
                                 },
                                 {
@@ -299,7 +299,7 @@
                                 },
                                 {
                                     "userEnteredValue": {
-                                        "stringValue": "11/20/2027"
+                                        "stringValue": "2027-11-20T15:00:00.000000+00:00"
                                     }
                                 },
                                 {
@@ -323,7 +323,7 @@
                                 },
                                 {
                                     "userEnteredValue": {
-                                        "stringValue": "11/20/2028"
+                                        "stringValue": "2028-11-20T15:00:00.000000+00:00"
                                     }
                                 },
                                 {
@@ -347,7 +347,7 @@
                                 },
                                 {
                                     "userEnteredValue": {
-                                        "stringValue": "9/25/2019"
+                                        "stringValue": "2019-09-25T15:00:00.000000+00:00"
                                     }
                                 },
                                 {
@@ -371,7 +371,7 @@
                                 },
                                 {
                                     "userEnteredValue": {
-                                        "stringValue": "5/17/2019"
+                                        "stringValue": "2019-05-17T15:00:00.000000+00:00"
                                     }
                                 },
                                 {
@@ -395,7 +395,7 @@
                                 },
                                 {
                                     "userEnteredValue": {
-                                        "stringValue": "11/15/2019"
+                                        "stringValue": "2019-10-17T15:00:00.000000+00:00"
                                     }
                                 },
                                 {
@@ -454,7 +454,7 @@
                                 },
                                 {
                                     "userEnteredValue": {
-                                        "stringValue": "9/10/2018"
+                                        "stringValue": "2018-09-10T15:52:27.498123+00:00"
                                     }
                                 },
                                 {
@@ -478,7 +478,7 @@
                                 },
                                 {
                                     "userEnteredValue": {
-                                        "stringValue": "9/13/2018"
+                                        "stringValue": "2018-09-13T15:52:27.498123+00:00"
                                     }
                                 },
                                 {
@@ -502,7 +502,7 @@
                                 },
                                 {
                                     "userEnteredValue": {
-                                        "stringValue": "8/15/2019"
+                                        "stringValue": "2019-08-15T15:52:27.498123+00:00"
                                     }
                                 },
                                 {
@@ -526,7 +526,7 @@
                                 },
                                 {
                                     "userEnteredValue": {
-                                        "stringValue": "8/28/2019"
+                                        "stringValue": "2019-08-28T15:52:27.498123+00:00"
                                     }
                                 },
                                 {
@@ -550,7 +550,7 @@
                                 },
                                 {
                                     "userEnteredValue": {
-                                        "stringValue": "4/4/2019"
+                                        "stringValue": "2019-04-04T15:52:27.498123+00:00"
                                     }
                                 },
                                 {
@@ -574,7 +574,7 @@
                                 },
                                 {
                                     "userEnteredValue": {
-                                        "stringValue": "5/10/2019"
+                                        "stringValue": "2019-05-10T15:52:27.498123+00:00"
                                     }
                                 },
                                 {
@@ -598,7 +598,7 @@
                                 },
                                 {
                                     "userEnteredValue": {
-                                        "stringValue": "4/20/2019"
+                                        "stringValue": "2019-04-20T15:52:27.498123+00:00"
                                     }
                                 },
                                 {
@@ -622,7 +622,7 @@
                                 },
                                 {
                                     "userEnteredValue": {
-                                        "stringValue": "5/1/2019"
+                                        "stringValue": "2019-05-01T15:52:27.498123+00:00"
                                     }
                                 },
                                 {
@@ -646,7 +646,7 @@
                                 },
                                 {
                                     "userEnteredValue": {
-                                        "stringValue": "10/5/2019"
+                                        "stringValue": "2019-10-05T15:52:27.498123+00:00"
                                     }
                                 },
                                 {
@@ -670,7 +670,7 @@
                                 },
                                 {
                                     "userEnteredValue": {
-                                        "stringValue": "10/9/2019"
+                                        "stringValue": "2019-10-09T15:52:27.498123+00:00"
                                     }
                                 },
                                 {

--- a/python/hackathon_app/tests/integration/test_hackathons.py
+++ b/python/hackathon_app/tests/integration/test_hackathons.py
@@ -20,9 +20,9 @@ def test_rows_returns_hackathons(
 def test_get_upcoming_hackathons(
     hackathons: sheets.Hackathons, test_hackathons: List[sheets.Hackathon]
 ):
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
     up_coming_expected = sorted(
-        (h for h in test_hackathons if h.date >= datetime.date.today()),
-        key=lambda ht: ht.id,
+        (h for h in test_hackathons if h.date >= now), key=lambda ht: ht.id
     )
     up_coming_actual = sorted(hackathons.get_upcoming(), key=lambda ht: ht.id)
     assert up_coming_actual == up_coming_expected
@@ -31,13 +31,13 @@ def test_get_upcoming_hackathons(
 def test_get_upcoming_hackathons_with_cutoff(
     hackathons: sheets.Hackathons, test_hackathons: List[sheets.Hackathon]
 ):
-    cutoff = datetime.date.today() + datetime.timedelta(days=60)
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    cutoff = now + datetime.timedelta(days=60)
 
     # setup some hackathons to occur within cutoff date
     # ensure we at most 3 hackathons so we don't decrement date into the past
     up_coming_expected = sorted(
-        (h for h in test_hackathons if h.date >= datetime.date.today()),
-        key=lambda ht: ht.id,
+        (h for h in test_hackathons if h.date >= now), key=lambda ht: ht.id
     )[:3]
     for d, hackathon in enumerate(up_coming_expected, start=1):
         hackathon.date = cutoff - datetime.timedelta(days=2 * d)

--- a/python/hackathon_app/tests/integration/test_sheets.py
+++ b/python/hackathon_app/tests/integration/test_sheets.py
@@ -35,7 +35,8 @@ def test_register_user_registers(
     last_registrant = all_registrants[-1]
     assert last_registrant.user_email == new_user.email
     assert last_registrant.hackathon_name == "sanfrancisco_2019"
-    assert last_registrant.date_registered == datetime.date.today()
+    assert last_registrant.date_registered
+    assert last_registrant.date_registered.date() == datetime.date.today()
     assert last_registrant.attended is None
 
 
@@ -59,14 +60,16 @@ def test_register_user_registers_when_user_exists(
     )
     sheets.register_user(hackathon="newhackathon_2019", user=new_user)
 
-    all_users = users.rows()
-    assert len(all_users) == len(test_users)
+    all_users = sorted(users.rows(), key=lambda a: a.id)
+    test_users = sorted(test_users, key=lambda t: t.id)
+    assert all_users == test_users
 
     all_registrants = registrations.rows()
     last_registrant = all_registrants[-1]
     assert last_registrant.user_email == existing_user.email
     assert last_registrant.hackathon_name == "newhackathon_2019"
-    assert last_registrant.date_registered == datetime.date.today()
+    assert last_registrant.date_registered
+    assert last_registrant.date_registered.date() == datetime.date.today()
     assert last_registrant.attended is None
 
 


### PR DESCRIPTION
For wait-list purposes we'll need to know exactly when a user
registered. For consistency, we'll keep track of everything to the
python default of microseconds and store it in UTC. Higher level
business/display logic can choose convert to a shorter/different format.

also: run sheets tests faster
reset the sheet instead of create/delete each time. cuts current test
run time roughly in half